### PR TITLE
Introduced skim_underscore

### DIFF
--- a/vendor/assets/javascripts/skim_underscore.js.coffee
+++ b/vendor/assets/javascripts/skim_underscore.js.coffee
@@ -1,0 +1,35 @@
+_._escape = _.escape
+
+_.escape = (string)->
+  return string if string.skimSafe
+  result = _._escape(string)
+  result.skimSafe = true
+  result
+
+this.Skim =
+  access: (name) ->
+    value = @[name]
+    value = value.call(@) if _.isFunction(value)
+    return [@]            if value == true
+    return false          if value == false or !value?
+    return [value]        if _.isArray(value)
+    return false          if value.length == 0
+    return value
+
+  withContext: (context, block) ->
+    create = (o) ->
+      F = ->
+      F.prototype = o
+      new F
+
+    context = create(context)
+
+    context.safe ||= @safe || (value) ->
+      return value if value?.skimSafe
+      result = new String(value ? '')
+      result.skimSafe = true
+      result
+
+    context.escape ||= @escape || _.escape
+
+    block.call(context)


### PR DESCRIPTION
If user is using backbone.js or simply underscore.js it is better to `//=require skim_underscore`. skim_uderscore:
- Overrides _.escape to return string with skimSafe flag
- Uses underscore functions in access method
- Uses _.escape function

This is just experiment. Any thoughts on this?
