### PR TITLE
Failing test

### DIFF
--- a/test/test_code_blocks.rb
+++ b/test/test_code_blocks.rb
@@ -66,6 +66,16 @@ p
     assert_html '<p>Hey!Hey!Hey!</p>', source
   end
 
+  def test_render_with_control_code_for_own_of_loop
+    source = %q{
+p
+  - for own key, value of {user: 'name'}
+    | #{user} #{name}
+}
+
+    assert_html '<p>user name</p>', source
+  end
+
   def test_captured_code_block_with_conditional
     source = %q{
 = @callback "Hello Ruby!", ->


### PR DESCRIPTION
Showing that we can't use 

``` coffeescript
for own key, value of object
```

Have to wrap template somehow. 
