### PR TITLE
Manually append assets path if Rails not available

### DIFF
--- a/lib/skim.rb
+++ b/lib/skim.rb
@@ -9,8 +9,5 @@ require "skim/engine"
 require "skim/template"
 require "skim/version"
 
-require "skim/rails" if Object.const_defined?(:Rails)
-
-require "sprockets"
-Sprockets::Engines # force autoload
-Sprockets.register_engine ".skim", Skim::Template
+require "skim/rails" if defined?(Rails::Engine)
+require "skim/sprockets"

--- a/lib/skim/sprockets.rb
+++ b/lib/skim/sprockets.rb
@@ -1,0 +1,7 @@
+require "sprockets"
+
+Sprockets.register_engine ".skim", Skim::Template
+
+unless defined?(Rails::Engine)
+  Sprockets.append_path File.expand_path('../../../vendor/assets/javascripts', __FILE__)
+end


### PR DESCRIPTION
Small changes to make it work fully with any Sprockets-based asset pipeline.  If Rails isn't available in the project, the paths need to be added to Sprockets manually.  I've got a Sinatra app with Sprockets, and with these changes it works perfectly!
