### PR TITLE
Add command-line interface (bin/skim)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,3 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
-bin

--- a/bin/skim
+++ b/bin/skim
@@ -1,0 +1,6 @@
+#!/usr/bin/env ruby
+
+$:.unshift File.dirname(__FILE__) + '/../lib'
+require 'skim/command'
+
+Skim::Command.new(ARGV).run

--- a/lib/skim/command.rb
+++ b/lib/skim/command.rb
@@ -1,0 +1,141 @@
+require 'skim'
+require 'optparse'
+
+module Skim
+  class Command
+    def initialize(args)
+      @args = args
+      @options = {}
+    end
+
+    # Run command
+    def run
+      @opts = OptionParser.new(&method(:set_opts))
+      @opts.parse!(@args)
+      process
+    end
+
+    private
+
+    # Configure OptionParser
+    def set_opts(opts)
+      opts.on('-s', '--stdin', 'Read input from standard input instead of an input file') do
+        @input = $stdin
+      end
+
+      opts.on('-e', '--export', 'Assign to module.exports for CommonJS require') do
+        @export = true
+      end
+
+      opts.on('-n', '--node-global', 'Use Node.js global object for global assignments') do
+        @node_global = true
+      end
+
+      opts.on('--jst', 'Assign to global JST object keyed by truncated filename') do
+        @assign_object_name = 'JST'
+      end
+
+      opts.on('--assign variableName', 'Assign to a global variable') do |str|
+        @assign_variable_name = str
+      end
+
+      opts.on('--assign-object objectName', 'Assign to a global object keyed by truncated filename') do |str|
+        @assign_object_name = str
+      end
+
+      opts.on('--asset-only', 'Output only the Skim preamble asset') do
+        @asset_only = true
+      end
+
+      opts.on('--omit-asset', 'Omit Skim preamble asset from output') do
+        @options[:use_asset] = true
+      end
+
+      opts.on('--trace', 'Show a full traceback on error') do
+        @trace = true
+      end
+
+      opts.on('-o', '--option name=code', String, 'Set skim option') do |str|
+        parts = str.split('=', 2)
+        Engine.options[parts.first.gsub(/\A:/, '').to_sym] = eval(parts.last)
+      end
+
+      opts.on('-r', '--require library', "Load library or plugin") do |lib|
+        require lib.strip
+      end
+
+      opts.on_tail('-h', '--help', 'Show this help message') do
+        puts opts
+        exit
+      end
+
+      opts.on_tail('-v', '--version', 'Print version number') do
+        puts "Skim #{VERSION}"
+        exit
+      end
+    end
+
+    # Process command
+    def process
+      args = @args.dup
+      result = if @asset_only
+        CoffeeScript.compile(Skim::Template.skim_src)
+      else
+        unless @input
+          filename = args.shift
+          if filename
+            @filename = filename
+            @input = File.open(filename, 'r')
+          else
+            @filename = 'STDIN'
+            @input = $stdin
+          end
+        end
+
+        locals = @options.delete(:locals) || {}
+        Template.new(@filename, @options) { @input.read }.render(nil, locals)
+      end
+
+      result = prepend_assignment(result)
+
+      rescue Exception => ex
+        raise ex if @trace || SystemExit === ex
+        $stderr.print "#{ex.class}: " if ex.class != RuntimeError
+        $stderr.puts ex.message
+        $stderr.puts '  Use --trace for backtrace.'
+        exit 1
+      else
+        unless @options[:output]
+          filename = args.shift
+          @options[:output] = filename ? File.open(filename, 'w') : $stdout
+        end
+        @options[:output].puts(result)
+        exit 0
+    end
+
+    def prepend_assignment(result)
+      assignment = ''
+      initialization = ''
+
+      global = 'this'
+      if @node_global
+        global = 'global'
+        result.sub!(/(this)(\.Skim =)/) {"#{global}#{$2}"}
+      end
+
+      assignment += "module.exports = " if @export
+      assignment += "#{global}.#{@assign_variable_name} = " if @assign_variable_name
+      if @assign_object_name
+        object_name = "#{global}.#{@assign_object_name}"
+        initialization = "#{object_name} || (#{object_name} = {});\n"
+        assignment += "#{object_name}[#{truncated_filename.inspect}] = "
+      end
+
+      assignment.empty? ? result : (initialization + assignment + result)
+    end
+
+    def truncated_filename
+      @filename.sub(/\.[^#{File::SEPARATOR}]*\Z/, '')
+    end
+  end
+end

--- a/lib/skim/template.rb
+++ b/lib/skim/template.rb
@@ -17,7 +17,7 @@ module Skim
 <<-SRC
 #{self.class.skim_src unless engine.options[:use_asset]}
 return (context = {}) ->
-  Skim.withContext.call {}, context, ->
+  (context.Skim || Skim).withContext.call {}, context, ->
 #{src}
 SRC
     end

--- a/skim.gemspec
+++ b/skim.gemspec
@@ -12,6 +12,7 @@ Sprockets-based asset pipeline.}
 
   gem.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   gem.files         = `git ls-files`.split("\n")
+  gem.executables   = gem.files.grep(%r{^bin/}) { |f| File.basename(f) }
   gem.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   gem.name          = "skim"
   gem.require_paths = ["lib"]

--- a/test/test_commands.rb
+++ b/test/test_commands.rb
@@ -1,0 +1,203 @@
+# coding: utf-8
+require 'helper'
+require 'open3'
+require 'tempfile'
+
+class TestSkimCommands < Minitest::Test
+  # nothing complex
+  STATIC_TEMPLATE = "p Hello World!\n"
+
+  # requires a `name` variable to exist at render time
+  DYNAMIC_TEMPLATE = "p Hello \#{name}!\n"
+
+  # a more complex example
+  LONG_TEMPLATE = "h1 Hello\np\n  | World!\n  small Tiny text"
+
+  # exception raising example
+  INVALID_TEMPLATE = '- if true'
+
+  def test_option_help
+    out, err = exec_skim '--help'
+    assert err.empty?
+    assert_match /Show this help message/, out
+  end
+
+  def test_option_version
+    out, err = exec_skim '--version'
+    assert err.empty?
+    assert_match /\ASkim #{Regexp.escape Skim::VERSION}$/, out
+  end
+
+  def test_export
+    prepare_common_test STATIC_TEMPLATE, '--export' do |out, err|
+      assert err.empty?
+      assert_equal "<p>Hello World!</p>", evaluate_node(out, 'module.exports()')
+    end
+  end
+
+  def test_assign_variable
+    prepare_common_test STATIC_TEMPLATE, '--assign', 'myFunction' do |out, err|
+      assert err.empty?
+      assert_equal "<p>Hello World!</p>", evaluate(out, 'myFunction()')
+    end
+  end
+
+  def test_assign_object
+    with_tempfile STATIC_TEMPLATE do |in_file|
+      out, err = exec_skim '--assign-object', 'myObject', in_file
+      assert err.empty?
+      key = in_file.chomp(File.extname(in_file))
+      assert_equal "<p>Hello World!</p>", evaluate(out, "myObject[#{key.inspect}]()")
+    end
+  end
+
+  def test_jst
+    with_tempfile STATIC_TEMPLATE do |in_file|
+      out, err = exec_skim '--jst', in_file
+      assert err.empty?
+      key = in_file.chomp(File.extname(in_file))
+      assert_equal "<p>Hello World!</p>", evaluate(out, "JST[#{key.inspect}]()")
+    end
+  end
+
+  def test_node_global
+    prepare_common_test STATIC_TEMPLATE, '--node-global', '--assign', 'myFunction' do |out, err|
+      assert err.empty?
+      assert_match /global\.Skim/, out
+      assert_equal "<p>Hello World!</p>", evaluate_node(out, 'global.myFunction()')
+    end
+  end
+
+  def test_asset_only
+    out, err = exec_skim '--asset-only'
+    assert err.empty?
+    assert_match %r{withContext\: function}, out
+  end
+
+  def test_omit_asset
+    prepare_common_test STATIC_TEMPLATE, '--omit-asset' do |out, err|
+      assert err.empty?
+      refute_match %r{withContext\: function}, out
+    end
+  end
+
+  def test_require
+    with_tempfile 'puts "Not in skim"', 'rb' do |lib|
+      prepare_common_test STATIC_TEMPLATE, '--require', lib, stdin_file: false, file_file: false do |out, err|
+        assert err.empty?
+        assert_match %r{\ANot in skim\n}, out
+      end
+    end
+  end
+
+  def test_error
+    prepare_common_test INVALID_TEMPLATE, stdin_file: false do |out, err|
+      assert out.empty?
+      assert_match /SyntaxError/, err
+      assert_match /Use --trace for backtrace/, err
+    end
+  end
+
+  def test_trace_error
+    prepare_common_test INVALID_TEMPLATE, '--trace', stdin_file: false do |out, err|
+      assert out.empty?
+      assert_match /SyntaxError/, err
+      assert_match /bin\/skim/, err
+    end
+  end
+
+private
+
+  # Executes a test (given as block) four times:
+  #
+  # 1. Read from $stdin, write to $stdout
+  # 2. Read from file, write to $stdout
+  # 3. Read from $stdin, write to file
+  # 4. Read from file, write to file
+  #
+  # Each of the above test executions yields a tuple (out, err).
+  # Any args given are passed to the skim command (before input/output args).
+  def prepare_common_test(content, *args)
+    options = Hash === args.last ? args.pop : {}
+
+    # case 1. $stdin → $stdout
+    unless options[:stdin_stdout] == false
+      out, err = exec_skim *args, '--stdin' do |i|
+        i.write content
+      end
+      yield out, err
+    end
+
+    # case 2. file → $stdout
+    unless options[:file_stdout] == false
+      with_tempfile content do |in_file|
+        out, err = exec_skim *args, in_file
+        yield out, err
+      end
+    end
+
+    # case 3. $stdin → file
+    unless options[:stdin_file] == false
+      with_tempfile content do |out_file|
+        _, err = exec_skim *args, '--stdin', out_file do |i|
+          i.write content
+        end
+        yield File.read(out_file), err
+      end
+    end
+
+    # case 4. file → file
+    unless options[:file_file] == false
+      with_tempfile '' do |out_file|
+        with_tempfile content do |in_file|
+          _, err = exec_skim *args, in_file, out_file do |i|
+            i.write content
+          end
+          yield File.read(out_file), err
+        end
+      end
+    end
+  end
+
+  def evaluate(src, expression)
+    ExecJS.compile(src).eval(expression)
+  end
+
+  def evaluate_node(src, expression)
+    evaluate("var module = {};\nvar global = this;\n" + src, expression)
+  end
+
+  # Calls bin/skim as a subprocess.
+  #
+  # Yields $stdin to the caller and returns a tupel (out, err) with the
+  # contents of $stdout and $stderr.
+  def exec_skim(*args)
+    out, err = nil, nil
+
+    Open3.popen3 'ruby', 'bin/skim', *args do |stdin, stdout, stderr, wait_thread|
+      yield stdin if block_given?
+      stdin.close
+      out, err = stdout.read, stderr.read
+    end
+
+    return out, err
+  end
+
+  # Creates a temporary file with the given content and yield the path
+  # to this file. The file itself is only available inside the block and
+  # will be deleted afterwards.
+  def with_tempfile(content=nil, extname='skim')
+    f = Tempfile.new ['skim', ".#{extname}"]
+    if content
+      f.write content
+      f.flush # ensure content is actually saved to disk
+      f.rewind
+    end
+
+    yield f.path
+  ensure
+    f.close
+    f.unlink
+  end
+
+end


### PR DESCRIPTION
@jfirebaugh and all project watchers: Please send me your feedback about this command-line interface. I plan to merge it in a few days.

This CLI will allow Skim to be used in Gulp and Grunt workflows, extending the reach of Skim from the Ruby world into the JS/ES/CoffeeScript communities.

Features:

- Options to output Skim asset and templates separately.
- Options to assign template function to `module.exports`, a global function variable, or a global object (keyed by filename, as Sprockets does with its `JST` object).

Usage: `skim [options]`

    -s, --stdin                      Read input from standard input instead of an input file
    -e, --export                     Assign to module.exports for CommonJS require
    -n, --node-global                Use Node.js global object for global assignments
        --jst                        Assign to global JST object keyed by truncated filename
        --assign variableName        Assign to a global variable
        --assign-object objectName   Assign to a global object keyed by truncated filename
        --asset-only                 Output only the Skim preamble asset
        --omit-asset                 Omit Skim preamble asset from output
        --trace                      Show a full traceback on error
    -o, --option name=code           Set skim option
    -r, --require library            Load library or plugin
    -h, --help                       Show this help message
    -v, --version                    Print version number

Skim templates now also support dependency injection for the Skim asset, instead of using a global Skim variable. Example in Node.js:

```javascript
var Skim = require('./skim_asset_module.js')
var template = require('./template_module.js');
console.log(template({username: 'svicalifornia', Skim: Skim}));
```