### PR TITLE
support Sprockets 4 API for Rails 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: ruby
 rvm:
-  - 2.3.1
+  - 2.7.1
 sudo: false

--- a/History.md
+++ b/History.md
@@ -1,5 +1,9 @@
 # master
 
+# 0.11.0
+
+* Compatibility with Rails 6 and Sprockets 4
+
 # 0.10.0
 
 * Compatibility with Rails 4.2, Slim 3, and Sprockets 3

--- a/lib/skim/sprockets.rb
+++ b/lib/skim/sprockets.rb
@@ -1,6 +1,15 @@
 require "sprockets"
 
-Sprockets.register_engine ".skim", Skim::Template
+if Sprockets.respond_to?(:register_transformer)
+  Sprockets.register_mime_type 'text/skim', extensions: ['.skim', '.jst.skim'], charset: :unicode
+  Sprockets.register_transformer 'text/skim', 'application/javascript+function', Skim::Template
+end
+
+if Sprockets.respond_to?(:register_engine)
+  args = ['.skim', Skim::Template]
+  args << { mime_type: 'application/javascript', silence_deprecation: true } if Sprockets::VERSION.start_with?('3')
+  Sprockets.register_engine(*args)
+end
 
 unless defined?(Rails::Engine)
   Sprockets.append_path File.expand_path('../../../vendor/assets/javascripts', __FILE__)

--- a/lib/skim/template.rb
+++ b/lib/skim/template.rb
@@ -6,6 +6,14 @@ module Skim
   class Template
     self.default_mime_type = "application/javascript"
 
+    def self.call(input)
+      source   = input[:data]
+      context  = input[:environment].context_class.new(input)
+
+      result = new { source }.render
+      context.metadata.merge(data: result)
+    end
+
     def coffee_script_src
 
       engine = Engine.new(options.merge({

--- a/lib/skim/version.rb
+++ b/lib/skim/version.rb
@@ -1,3 +1,3 @@
 module Skim
-  VERSION = "0.10.0"
+  VERSION = "0.11.0"
 end

--- a/skim.gemspec
+++ b/skim.gemspec
@@ -21,7 +21,7 @@ Sprockets-based asset pipeline.}
   gem.add_dependency "slim", '>= 3.0'
   gem.add_dependency "coffee-script"
   gem.add_dependency "coffee-script-source", ">= 1.2.0"
-  gem.add_dependency "sprockets", "~> 4"
+  gem.add_dependency "sprockets", ">= 3.0", "< 5.0"
 
   gem.add_development_dependency "rake"
   gem.add_development_dependency "pry"

--- a/skim.gemspec
+++ b/skim.gemspec
@@ -21,12 +21,11 @@ Sprockets-based asset pipeline.}
   gem.add_dependency "slim", '>= 3.0'
   gem.add_dependency "coffee-script"
   gem.add_dependency "coffee-script-source", ">= 1.2.0"
-  gem.add_dependency "sprockets", ">= 2", "< 4"
+  gem.add_dependency "sprockets", "~> 4"
 
   gem.add_development_dependency "rake"
   gem.add_development_dependency "pry"
   gem.add_development_dependency "execjs"
   gem.add_development_dependency "minitest-reporters"
-  gem.add_development_dependency "therubyracer"
-  gem.add_development_dependency "libv8", "~> 3.16.14.0"
+  gem.add_development_dependency "libv8", "~> 8"
 end


### PR DESCRIPTION
Hi @svicalifornia! 

I tried the branch from @zamakkat (https://github.com/appjudo/skim/pull/57) on a fresh Rails 6 app without much success. 
But I think this was just due to the fact that all the involved gems updated too quickly with breaking API changes. 

So I updated the API accordingly ([reference](https://github.com/rails/sprockets/blob/master/guides/extending_sprockets.md#supporting-all-versions-of-sprockets-in-processors)).

Tests are passing and I bundled the code on both Rails 5 and Rails 6 with beautifully rendering `*.jst.skim` templates, 
without any issues. 

I hope this is still useful for other people with big "legacy" views to postpone the rewrite a little further (like in my case 😄).

![](https://media.giphy.com/media/bqalUGFYfyHzW/giphy.gif)